### PR TITLE
Fuzz rr ops

### DIFF
--- a/fuzz/fuzzers/fuzzer_script_op.rs
+++ b/fuzz/fuzzers/fuzzer_script_op.rs
@@ -18,7 +18,7 @@ fn iter_ops(i: &mut DNSIterable, ops: &[u8]) -> u64
                 }
             },
             1 => { i.offset_next() },
-            2 => { i.set_offset((prev_op * *op) as usize); 1 },
+            2 => { i.set_offset((prev_op as usize * *op as usize) as usize); 1 },
             3 => { i.set_offset_next((prev_op * *op) as usize); 1 },
             4 => { i.invalidate(); 1 },
             5 => { if i.is_tombstone() { 0 } else { 1 } },

--- a/fuzz/fuzzers/fuzzer_script_op.rs
+++ b/fuzz/fuzzers/fuzzer_script_op.rs
@@ -5,11 +5,48 @@ extern crate dnssector;
 use compress::*;
 use dnssector::*;
 
+fn iter_ops(i: &mut DNSIterable, ops: &[u8]) -> u64
+{
+    let mut ret = 0;
+    let mut prev_op = 0 as u8;
+    for op in ops {
+        let res = match *op {
+            0 => {
+                match i.offset() {
+                    Some(x) => x,
+                    None => 0,
+                }
+            },
+            1 => { i.offset_next() },
+            2 => { i.set_offset((prev_op * *op) as usize); 1 },
+            3 => { i.set_offset_next((prev_op * *op) as usize); 1 },
+            4 => { i.invalidate(); 1 },
+            5 => { if i.is_tombstone() { 0 } else { 1 } },
+            6 => { i.recompute_rr(); 1 },
+            7 => { i.recompute_sections();1  },
+            8 => { let p = i.packet(); p[0] as usize },
+            9 => { let slice = i.name_slice(); slice[0] as usize },
+            10 => { let slice = i.rdata_slice(); slice[0] as usize },
+            11 => { let mut slice = i.rdata_slice_mut(); slice[0] /= 2; slice[0] as usize },
+            12 => {
+                match i.uncompress() {
+                    Ok(()) => 1,
+                    _ => 2,
+                }
+            },
+            _ => 1,
+        };
+        ret += res;
+        prev_op = *op;
+    }
+    ret as u64
+}
 fuzz_target!(|input: &[u8]| {
-    if input.len() < 8 {
+    if input.len() < 64 {
         return;
     }
-    let (ops, packet) = input.split_at(8);
+    let (all_ops, packet) = input.split_at(64);
+    let (ops, rr_ops) = input.split_at(32);
     let mut cloned_packet  = packet.to_vec();
     let mut cloned_packet = cloned_packet.as_mut();
     let dns_sector = DNSSector::new(packet.to_vec()).unwrap();
@@ -35,12 +72,42 @@ fuzz_target!(|input: &[u8]| {
             6 => parsed.opcode() as u64,
             7 => {parsed.set_opcode(u8_arg); 1},
             8 => {parsed.recompute(); 1},
-            9 => {parsed.into_iter_question(); 1}
-            10 => {parsed.into_iter_answer(); 1}
-            11 => {parsed.into_iter_nameservers(); 1}
-            12 => {parsed.into_iter_additional(); 1}
-            13 => {parsed.into_iter_additional_including_opt(); 1}
-            14 => {parsed.into_iter_edns(); 1}
+            9 => {
+                match parsed.into_iter_question() {
+                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    None => 0,
+                }
+            }
+            10 => {
+                match parsed.into_iter_answer() {
+                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    None => 0,
+                }
+            }
+            11 => {
+                match parsed.into_iter_nameservers() {
+                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    None => 0,
+                }
+            }
+            12 => {
+                match parsed.into_iter_additional() {
+                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    None => 0,
+                }
+            }
+            13 => {
+                match parsed.into_iter_additional_including_opt() {
+                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    None => 0,
+                }
+            }
+            14 => {
+                match parsed.into_iter_edns() {
+                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    None => 0,
+                }
+            }
             15 => DNSSector::qdcount(cloned_packet) as u64,
             16 => {DNSSector::set_qdcount(cloned_packet, u16_arg); 1}
             17 => DNSSector::ancount(cloned_packet) as u64,

--- a/fuzz/fuzzers/fuzzer_script_op.rs
+++ b/fuzz/fuzzers/fuzzer_script_op.rs
@@ -1,14 +1,15 @@
 #![no_main]
-#[macro_use] extern crate libfuzzer_sys;
+#[macro_use]
+extern crate libfuzzer_sys;
 extern crate dnssector;
 
 use compress::*;
 use dnssector::*;
 
-fn iter_ops(i: &mut DNSIterable, ops: &[u8]) -> u64
-{
+fn iter_ops(i: &mut DNSIterable, ops: &[u8]) -> u64 {
     let mut ret = 0;
     let mut prev_op = 0 as u8;
+
     for op in ops {
         let res = match *op {
             0 => {
@@ -16,24 +17,45 @@ fn iter_ops(i: &mut DNSIterable, ops: &[u8]) -> u64
                     Some(x) => x,
                     None => 0,
                 }
-            },
-            1 => { i.offset_next() },
-            2 => { i.set_offset((prev_op as usize * *op as usize) as usize); 1 },
-            3 => { i.set_offset_next((prev_op * *op) as usize); 1 },
-            4 => { i.invalidate(); 1 },
-            5 => { if i.is_tombstone() { 0 } else { 1 } },
-            6 => { i.recompute_rr(); 1 },
-            7 => { i.recompute_sections();1  },
-            8 => { let p = i.packet(); p[0] as usize },
-            9 => { let slice = i.name_slice(); slice[0] as usize },
-            10 => { let slice = i.rdata_slice(); slice[0] as usize },
-            11 => { let mut slice = i.rdata_slice_mut(); slice[0] /= 2; slice[0] as usize },
+            }
+            1 => i.offset_next(),
+            5 => if i.is_tombstone() { 0 } else { 1 },
+            6 => {
+                i.recompute_rr();
+                1
+            }
+            7 => {
+                i.recompute_sections();
+                1
+            }
+            8 => {
+                match (i.offset()) {
+                    Some(_) => {
+                        let p = i.packet();
+                        p[0] as usize
+                    }
+                    None => 1,
+                }
+            }
+            9 => {
+                let slice = i.name_slice();
+                slice[0] as usize
+            }
+            10 => {
+                let slice = i.rdata_slice();
+                slice[0] as usize
+            }
+            11 => {
+                let mut slice = i.rdata_slice_mut();
+                slice[0] /= 2;
+                slice[0] as usize
+            }
             12 => {
                 match i.uncompress() {
                     Ok(()) => 1,
                     _ => 2,
                 }
-            },
+            }
             _ => 1,
         };
         ret += res;
@@ -41,13 +63,14 @@ fn iter_ops(i: &mut DNSIterable, ops: &[u8]) -> u64
     }
     ret as u64
 }
+
 fuzz_target!(|input: &[u8]| {
     if input.len() < 64 {
         return;
     }
     let (all_ops, packet) = input.split_at(64);
     let (ops, rr_ops) = input.split_at(32);
-    let mut cloned_packet  = packet.to_vec();
+    let mut cloned_packet = packet.to_vec();
     let mut cloned_packet = cloned_packet.as_mut();
     let dns_sector = DNSSector::new(packet.to_vec()).unwrap();
     let mut cloned_dns_sector = dns_sector.clone();
@@ -64,61 +87,136 @@ fuzz_target!(|input: &[u8]| {
         let u32_arg: u32 = prev_op << 16 | prev_prev_op;
         let _ = match *op {
             0 => parsed.tid() as u64,
-            1 => {parsed.set_tid(u16_arg); 1},
+            1 => {
+                parsed.set_tid(u16_arg);
+                1
+            }
             2 => parsed.flags() as u64,
-            3 => {parsed.set_flags(u32_arg); 1},
+            3 => {
+                parsed.set_flags(u32_arg);
+                1
+            }
             4 => parsed.rcode() as u64,
-            5 => {parsed.set_rcode(u8_arg); 1},
+            5 => {
+                parsed.set_rcode(u8_arg);
+                1
+            }
             6 => parsed.opcode() as u64,
-            7 => {parsed.set_opcode(u8_arg); 1},
-            8 => {parsed.recompute(); 1},
+            7 => {
+                parsed.set_opcode(u8_arg);
+                1
+            }
+            8 => {
+                parsed.recompute();
+                1
+            }
             9 => {
                 match parsed.into_iter_question() {
-                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    Some(mut i) => {
+                        match i.next() {
+                            Some(mut i) => iter_ops(&mut i, rr_ops),
+                            None => 1,
+                        }
+                    }
                     None => 0,
                 }
             }
             10 => {
                 match parsed.into_iter_answer() {
-                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    Some(mut i) => {
+                        match i.next() {
+                            Some(mut i) => iter_ops(&mut i, rr_ops),
+                            None => 1,
+                        }
+                    }
                     None => 0,
                 }
             }
             11 => {
                 match parsed.into_iter_nameservers() {
-                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    Some(mut i) => {
+                        match i.next() {
+                            Some(mut i) => iter_ops(&mut i, rr_ops),
+                            None => 1,
+                        }
+                    }
                     None => 0,
                 }
             }
             12 => {
                 match parsed.into_iter_additional() {
-                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    Some(mut i) => {
+                        match i.next() {
+                            Some(mut i) => iter_ops(&mut i, rr_ops),
+                            None => 1,
+                        }
+                    }
                     None => 0,
                 }
             }
             13 => {
                 match parsed.into_iter_additional_including_opt() {
-                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    Some(mut i) => {
+                        match i.next() {
+                            Some(mut i) => iter_ops(&mut i, rr_ops),
+                            None => 1,
+                        }
+                    }
                     None => 0,
                 }
             }
             14 => {
                 match parsed.into_iter_edns() {
-                    Some(mut i) => iter_ops(&mut i, rr_ops),
+                    Some(mut i) => {
+                        match i.next() {
+                            Some(mut i) => iter_ops(&mut i, rr_ops),
+                            None => 1,
+                        }
+                    }
                     None => 0,
                 }
             }
             15 => DNSSector::qdcount(cloned_packet) as u64,
-            16 => {DNSSector::set_qdcount(cloned_packet, u16_arg); 1}
+            16 => {
+                DNSSector::set_qdcount(cloned_packet, u16_arg);
+                1
+            }
             17 => DNSSector::ancount(cloned_packet) as u64,
-            18 => {DNSSector::set_ancount(cloned_packet, u16_arg); 1}
+            18 => {
+                DNSSector::set_ancount(cloned_packet, u16_arg);
+                1
+            }
             19 => DNSSector::nscount(cloned_packet) as u64,
-            20 => {DNSSector::set_nscount(cloned_packet, u16_arg); 1}
+            20 => {
+                DNSSector::set_nscount(cloned_packet, u16_arg);
+                1
+            }
             21 => DNSSector::arcount(cloned_packet) as u64,
-            22 => {DNSSector::set_arcount(cloned_packet, u16_arg); 1}
-            23 => if cloned_dns_sector.set_offset(u32_arg as usize).is_ok() { 1 } else { 0 },
-            24 => if cloned_dns_sector.increment_offset(u32_arg as usize).is_ok() { 1 } else { 0 },
-            25 => if cloned_dns_sector.rr_rdlen().is_ok() { 1 } else { 0 },
+            22 => {
+                DNSSector::set_arcount(cloned_packet, u16_arg);
+                1
+            }
+            23 => {
+                if cloned_dns_sector.set_offset(u32_arg as usize).is_ok() {
+                    1
+                } else {
+                    0
+                }
+            }
+            24 => {
+                if cloned_dns_sector.increment_offset(u32_arg as usize).is_ok() {
+                    1
+                } else {
+                    0
+                }
+            }
+            25 => {
+                if cloned_dns_sector.rr_rdlen().is_ok() {
+                    1
+                } else {
+                    0
+                }
+            }
             26 => {
                 let mut maybe_parsed = cloned_dns_sector.clone().parse();
                 if maybe_parsed.is_ok() {
@@ -129,8 +227,14 @@ fuzz_target!(|input: &[u8]| {
                 } else {
                     0
                 }
-            },
-            27 => if cloned_dns_sector.edns_rr_rdlen().is_ok() { 1 } else { 0 },
+            }
+            27 => {
+                if cloned_dns_sector.edns_rr_rdlen().is_ok() {
+                    1
+                } else {
+                    0
+                }
+            }
             _ => 0,
         };
         prev_prev_op = *op as u32;
@@ -139,7 +243,7 @@ fuzz_target!(|input: &[u8]| {
 
     let packet = parsed.into_packet();
     let uncompressed = match Compress::uncompress(&packet) {
-        Err(_) => {},
+        Err(_) => {}
         Ok(packet) => {
             let dns_sector = DNSSector::new(packet).unwrap();
             let _ = dns_sector.parse();


### PR DESCRIPTION
This fuzzes operations on iterators obtained on the fuzzed packet (fuzzing inception :). This does trigger backtraces early on, but since we're setting offsets randomly, it's unsurprising. For example:
```
  11: dnssector::rr_iterator::RRIterator::recompute
             at src/rr_iterator.rs:477
  12: <dnssector::response_iterator::ResponseIterator<'t> as dnssector::rr_iterator::DNSIterable>::recompute_rr
             at src/response_iterator.rs:46
  13: fuzzer_script_op::iter_ops
             at fuzz/fuzzers/fuzzer_script_op.rs:25
  14: rust_fuzzer_test_input
             at fuzz/fuzzers/fuzzer_script_op.rs:95
  15: libfuzzer_sys::test_input_wrap::{{closure}}
             at /home/def/.cargo/git/checkouts/libfuzzer-sys-e07fde05820d7bc6/67f7399/src/lib.rs:11
  16: std::panicking::try::do_call
             at /checkout/src/libstd/panicking.rs:479
  17: <unknown>
```
so i'm thinking that this ties into the question of how do we handle operations on packets made bogus.
Also please note that this requires passing `-max_len` to the fuzzer, since we're using 64 bytes for fuzzing ops, and the default max len is only 64 bytes. I've used `cargo fuzz run fuzzer_script_op -- -max_len=64000`.