### PR TITLE
Allow converting "ANY" to Type::ANY

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -222,6 +222,7 @@ impl Type {
             s if s.eq_ignore_ascii_case("MX") => Ok(Type::MX),
             s if s.eq_ignore_ascii_case("SOA") => Ok(Type::SOA),
             s if s.eq_ignore_ascii_case("DS") => Ok(Type::DS),
+            s if s.eq_ignore_ascii_case("ANY") => Ok(Type::ANY),
             _ => bail!(DSError::UnsupportedRRType(rr_type_str.to_owned())),
         }
     }


### PR DESCRIPTION
This extends dnssector::constants::Type::from_string(...)
to allow converting to Type::ANY which can be useful for
some queries.